### PR TITLE
feat: resolve Postman environment variables via --env

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ BASE_URL=https://staging.example.com pytest generated_tests/test_api.py -v
 | `--out` | ✅ | Output path for generated pytest file |
 | `--base-url` | ❌ | Tip printed after generation (does not override env var) |
 | `--filter-folder` | ❌ | Generate tests only for the named Postman folder |
+| `--env` | ❌ | Postman environment JSON export to resolve `{{variables}}` |
 
 To regenerate tests for one folder, pass its Postman folder name:
 
@@ -71,6 +72,31 @@ postman2pytest \
   --out generated_tests/test_users.py \
   --filter-folder Users
 ```
+
+### Resolving environment variables
+
+Postman collections reference variables such as `{{base_url}}` and
+`{{auth_token}}`. Pass a Postman environment export with `--env` to resolve
+them:
+
+```bash
+postman2pytest \
+  --collection data/my_api.postman_collection.json \
+  --out generated_tests/test_api.py \
+  --env data/prod.postman_environment.json
+```
+
+- Non-secret variables are inlined as literal values in the generated tests.
+- Variables marked `secret` in the environment, and any variable not present
+  in it, become named pytest fixtures instead. The secret value never lands in
+  the generated source; the fixture reads it from the environment at run time
+  (and can be overridden in your own `conftest.py`).
+
+Resolution covers variables in request URLs and headers. Variables inside
+request bodies and form fields are not resolved yet and are left as-is.
+
+Without `--env`, variables are left as `os.environ.get("name", "")` lookups,
+exactly as before.
 
 ## Examples
 

--- a/core/environment.py
+++ b/core/environment.py
@@ -1,0 +1,83 @@
+"""
+Postman environment variable resolution.
+
+A Postman environment export looks like::
+
+    {
+      "name": "My Env",
+      "values": [
+        {"key": "base_url", "value": "https://api.example.com", "enabled": true, "type": "default"},
+        {"key": "auth_token", "value": "s3cr3t", "enabled": true, "type": "secret"}
+      ]
+    }
+
+Non-secret variables are inlined into the generated tests at generation time.
+Secret variables (``type: secret``) and variables absent from the environment
+become named pytest fixtures instead, so a secret value never lands in the
+generated source.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class _EnvVar:
+    value: str
+    secret: bool
+
+
+class Environment:
+    """Resolved Postman environment variables."""
+
+    def __init__(self, variables: dict[str, _EnvVar]) -> None:
+        self._vars = variables
+
+    @classmethod
+    def from_postman_export(cls, data: dict) -> Environment:
+        """Build an Environment from a parsed Postman environment export.
+
+        Disabled entries and entries without a key are skipped. A missing
+        ``enabled`` flag is treated as enabled (Postman omits it for active
+        variables). A missing ``type`` is treated as non-secret.
+        """
+        variables: dict[str, _EnvVar] = {}
+        for entry in data.get("values") or []:
+            if not isinstance(entry, dict):
+                continue
+            key = entry.get("key")
+            if not key:
+                continue
+            if entry.get("enabled", True) is False:
+                continue
+            secret = entry.get("type") == "secret"
+            variables[key] = _EnvVar(value=str(entry.get("value", "")), secret=secret)
+        return cls(variables)
+
+    def inline_value(self, name: str) -> str | None:
+        """Return the literal value to inline, or None if the variable must
+        become a fixture (it is secret, or absent from the environment)."""
+        var = self._vars.get(name)
+        if var is None or var.secret:
+            return None
+        return var.value
+
+    def is_secret(self, name: str) -> bool:
+        var = self._vars.get(name)
+        return bool(var and var.secret)
+
+    def needs_fixture(self, name: str) -> bool:
+        """True when ``{{name}}`` cannot be inlined (secret or unknown)."""
+        return self.inline_value(name) is None
+
+
+def load_environment(path: Path) -> Environment:
+    """Load and parse a Postman environment export from disk.
+
+    Raises FileNotFoundError if the path does not exist.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    return Environment.from_postman_export(json.loads(text))

--- a/core/environment.py
+++ b/core/environment.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -37,7 +38,7 @@ class Environment:
         self._vars = variables
 
     @classmethod
-    def from_postman_export(cls, data: dict) -> Environment:
+    def from_postman_export(cls, data: dict[str, Any]) -> Environment:
         """Build an Environment from a parsed Postman environment export.
 
         Disabled entries and entries without a key are skipped. A missing

--- a/core/generator.py
+++ b/core/generator.py
@@ -5,6 +5,7 @@ Takes a list of ParsedRequest objects and renders them via Jinja2.
 
 from __future__ import annotations
 
+import keyword
 import logging
 import re
 from datetime import datetime, timezone
@@ -12,6 +13,7 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+from core.environment import Environment as PostmanEnvironment
 from core.parser import ParsedRequest
 
 logger = logging.getLogger(__name__)
@@ -20,13 +22,54 @@ _TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
 _ENV_PREFIX_RE = re.compile(r"^ENV_\w+/?")
 _ENV_VAR_RE = re.compile(r"ENV_(\w+)")
 
+# A surviving variable becomes a pytest fixture only when its name is a usable,
+# non-colliding Python identifier. Digit-leading names ({{2fa}}), keywords, and
+# names that would shadow the generated module's own bindings fall back to an
+# os.environ lookup so the generated file always compiles and runs correctly.
+_RESERVED_FIXTURE_NAMES = frozenset(
+    {"url", "headers", "data", "body", "response", "requests", "os", "pytest", "json", "BASE_URL"}
+)
 
-def _strip_base_url(url: str) -> str:
+
+def _is_safe_fixture_name(name: str) -> bool:
+    return (
+        name.isidentifier() and not keyword.iskeyword(name) and name not in _RESERVED_FIXTURE_NAMES
+    )
+
+
+def _token_repr(name: str, fixture_mode: bool) -> str:
+    """Inline expression for one ENV_xxx token: a bare fixture reference when in
+    fixture_mode and the name is safe, otherwise an os.environ lookup."""
+    if fixture_mode and _is_safe_fixture_name(name):
+        return "{" + name + "}"
+    return "{os.environ.get('" + name + "', '')}"
+
+
+def _inline_env_tokens(value: str, env: PostmanEnvironment | None) -> str:
+    """Replace ENV_xxx tokens that resolve to an inlinable (non-secret, known)
+    value with the literal value. Secret and unknown variables are left as
+    ENV_xxx tokens so they fall through to os.environ / a fixture downstream."""
+    if env is None or "ENV_" not in value:
+        return value
+
+    def repl(match: re.Match[str]) -> str:
+        resolved = env.inline_value(match.group(1))
+        return resolved if resolved is not None else match.group(0)
+
+    return _ENV_VAR_RE.sub(repl, value)
+
+
+def _strip_base_url(url: str, fixture_mode: bool = False) -> str:
     """
     Transform ENV_xxx URLs for use in f-strings inside generated tests.
 
     ENV_base_url/api/v1/users  ->  api/v1/users
     path/ENV_version/users     ->  path/{os.environ.get('version', '')}/users
+
+    With fixture_mode (an environment was supplied via --env), remaining
+    ENV_xxx tokens become bare fixture references instead::
+
+        path/ENV_version/users  ->  path/{version}/users
 
     Absolute URLs (http:// or https://) are returned as-is. Note: this filter
     is no longer the only entry point. See _render_url, which routes absolute
@@ -35,16 +78,22 @@ def _strip_base_url(url: str) -> str:
     if url.startswith(("http://", "https://")):
         return url
     url = _ENV_PREFIX_RE.sub("", url)
-    url = _ENV_VAR_RE.sub(r"{os.environ.get('\1', '')}", url)
+    url = _ENV_VAR_RE.sub(lambda m: _token_repr(m.group(1), fixture_mode), url)
     return url
 
 
-def _render_url(url: str) -> str:
+def _render_url(url: str, env: PostmanEnvironment | None = None) -> str:
     """Render a URL as a Python expression for the generated test code.
 
-    Absolute URL (http:// or https://) -> JSON string literal, no BASE_URL.
-    Relative URL -> f-string with `{BASE_URL}/` prefix, interpolating any
-    ENV_xxx tokens as os.environ.get('xxx', '') lookups.
+    When an environment is provided, non-secret known variables are inlined
+    as literal values first; secret/unknown variables stay as os.environ
+    lookups.
+
+    Absolute URL (http:// or https://) -> JSON string literal, no BASE_URL
+    (or an f-string when it still carries unresolved variables).
+    Relative URL -> f-string with `{BASE_URL}/` prefix. Remaining ENV_xxx
+    tokens become bare fixture references ({name}) under --env, or
+    os.environ.get('xxx', '') lookups otherwise.
 
     Closes the bug where absolute URLs (Postman collections that mix
     internal endpoints with third-party API calls) were emitted as
@@ -52,9 +101,16 @@ def _render_url(url: str) -> str:
     """
     import json
 
+    url = _inline_env_tokens(url, env)
+    fixture_mode = env is not None
     if url.startswith(("http://", "https://")):
-        return json.dumps(url)
-    stripped = _strip_base_url(url)
+        if "ENV_" not in url:
+            return json.dumps(url)
+        # Absolute URL that still carries unresolved variables (e.g. an inlined
+        # base_url followed by a path variable). Render as an f-string so the
+        # remaining tokens are interpolated instead of leaking as raw text.
+        return 'f"' + _interpolate(url, fixture_mode) + '"'
+    stripped = _strip_base_url(url, fixture_mode=fixture_mode)
     return 'f"{BASE_URL}/' + stripped + '"'
 
 
@@ -68,41 +124,79 @@ def _escape_fstring_literal(literal: str) -> str:
     return literal.replace("\\", "\\\\").replace('"', '\\"').replace("{", "{{").replace("}", "}}")
 
 
-def _render_header_value(value: str) -> str:
+def _interpolate(value: str, fixture_mode: bool) -> str:
+    """Build the body of an f-string from a value containing ENV_xxx tokens.
+
+    Literal spans are escaped; each ENV_xxx token becomes a bare fixture
+    reference ({name}) in fixture_mode, or an os.environ.get lookup otherwise.
+    """
+    parts: list[str] = []
+    cursor = 0
+    for match in _ENV_VAR_RE.finditer(value):
+        parts.append(_escape_fstring_literal(value[cursor : match.start()]))
+        parts.append(_token_repr(match.group(1), fixture_mode))
+        cursor = match.end()
+    parts.append(_escape_fstring_literal(value[cursor:]))
+    return "".join(parts)
+
+
+def _render_header_value(value: str, env: PostmanEnvironment | None = None) -> str:
     """Render a header value as a Python expression.
 
     Plain values become a JSON string literal: "application/json".
     Values with ENV_xxx become a Python f-string: f"Bearer {os.environ.get('token', '')}"
 
-    Literal portions of the value (everything outside the ENV_xxx tokens)
-    must be escaped before they land inside the f-string. Without this
-    pass, a captured header containing a double quote or a curly brace
-    produces either a broken f-string or, worse, valid Python with extra
-    statements injected after the closing quote.
+    When an environment is provided, non-secret known variables are inlined as
+    literal values first; secret/unknown variables stay as os.environ lookups
+    (or fixture references), so a secret token never lands in the generated
+    source.
     """
     import json
 
+    value = _inline_env_tokens(value, env)
     if "ENV_" not in value:
         return json.dumps(value)
+    return 'f"' + _interpolate(value, fixture_mode=env is not None) + '"'
 
-    parts: list[str] = []
-    cursor = 0
-    for match in _ENV_VAR_RE.finditer(value):
-        parts.append(_escape_fstring_literal(value[cursor : match.start()]))
-        parts.append(f"{{os.environ.get('{match.group(1)}', '')}}")
-        cursor = match.end()
-    parts.append(_escape_fstring_literal(value[cursor:]))
-    return 'f"' + "".join(parts) + '"'
+
+def _collect_fixtures(req: ParsedRequest, env: PostmanEnvironment | None) -> list[str]:
+    """Variable names in this request that become named pytest fixtures.
+
+    A fixture is needed for every {{var}} that survives inlining (secret or
+    unknown). The leading URL variable is excluded: it maps to BASE_URL, not
+    a fixture. Only meaningful when an environment was supplied.
+    """
+    if env is None:
+        return []
+    names: set[str] = set()
+
+    def _add_safe(text: str) -> None:
+        names.update(n for n in _ENV_VAR_RE.findall(text) if _is_safe_fixture_name(n))
+
+    url = _inline_env_tokens(req.url, env)
+    if not url.startswith(("http://", "https://")):
+        url = _ENV_PREFIX_RE.sub("", url)  # relative: leading var -> BASE_URL, not a fixture
+    _add_safe(url)  # remaining url vars (absolute or relative)
+
+    for value in req.headers.values():
+        _add_safe(_inline_env_tokens(value, env))
+
+    return sorted(names)
 
 
 def generate(
     requests: list[ParsedRequest],
     collection_name: str,
     output_path: Path,
+    postman_env: PostmanEnvironment | None = None,
 ) -> None:
     """
     Render parsed requests into a pytest file at output_path.
     Creates parent directories if needed.
+
+    When postman_env is provided (from --env), non-secret variables are
+    resolved to literal values; secret/unknown variables stay as os.environ
+    lookups.
     """
     if not requests:
         logger.warning("No requests to generate. Output file not written.")
@@ -116,13 +210,18 @@ def generate(
     )
     env.filters["tojson"] = _to_python_repr
     env.filters["strip_base_url"] = _strip_base_url
-    env.filters["render_url"] = _render_url
-    env.filters["render_header_value"] = _render_header_value
+    env.filters["render_url"] = lambda url: _render_url(url, postman_env)
+    env.filters["render_header_value"] = lambda value: _render_header_value(value, postman_env)
 
     template = env.get_template("test_collection.jinja2")
 
+    fixtures_per_request = [_collect_fixtures(req, postman_env) for req in requests]
+    all_fixtures = sorted({name for fx in fixtures_per_request for name in fx})
+
     rendered = template.render(
         requests=requests,
+        fixtures_per_request=fixtures_per_request,
+        all_fixtures=all_fixtures,
         collection_name=collection_name,
         generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
     )

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ import sys
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
+from core.environment import load_environment
 from core.generator import generate
 from core.parser import ParsedRequest, parse_collection
 
@@ -56,6 +57,14 @@ def main() -> int:
     parser.add_argument(
         "--filter-folder",
         help="Only generate tests for requests in the named Postman folder (case-insensitive)",
+    )
+    parser.add_argument(
+        "--env",
+        help=(
+            "Path to a Postman environment JSON export. Non-secret variables are "
+            "resolved to literal values in the generated tests; secret and unknown "
+            "variables stay as os.environ lookups."
+        ),
     )
     parser.add_argument(
         "--max-input-mb",
@@ -104,8 +113,25 @@ def main() -> int:
         logger.error("No valid requests found in collection. Nothing to generate.")
         return 1
 
+    postman_env = None
+    if args.env:
+        env_path = Path(args.env)
+        if not env_path.exists():
+            logger.error("Environment file not found: %s", env_path)
+            return 1
+        try:
+            postman_env = load_environment(env_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.error("Could not read environment file %s: %s", env_path, exc)
+            return 1
+
     output_path = Path(args.out)
-    generate(requests, collection_name=collection_name, output_path=output_path)
+    generate(
+        requests,
+        collection_name=collection_name,
+        output_path=output_path,
+        postman_env=postman_env,
+    )
 
     print(f"\nGenerated {len(requests)} test(s) -> {output_path}")
     print(f"  Run with: pytest {output_path} -v")

--- a/templates/test_collection.jinja2
+++ b/templates/test_collection.jinja2
@@ -12,8 +12,16 @@ import requests
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:8080")
 
 
+{% for name in all_fixtures %}
+@pytest.fixture
+def {{ name }}():
+    """Postman variable '{{ name }}'. Set the {{ name }} environment variable, or override this fixture."""
+    return os.environ.get("{{ name }}", "")
+
+
+{% endfor %}
 {% for req in requests %}
-def {{ req.test_name }}():
+def {{ req.test_name }}({{ fixtures_per_request[loop.index0] | join(", ") }}):
     """{{ req.method }} {{ req.url }}{% if req.folder %} ({{ req.folder }}){% endif %}"""
     url = {{ req.url | render_url }}
     {% if req.headers %}

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,353 @@
+"""Tests for core/environment.py - Postman environment variable resolution."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.environment import Environment, load_environment
+
+# -- from_postman_export: parsing the Postman environment export shape --
+
+
+def test_parses_enabled_non_secret_values():
+    data = {
+        "name": "My Env",
+        "values": [
+            {
+                "key": "base_url",
+                "value": "https://api.example.com",
+                "enabled": True,
+                "type": "default",
+            },
+        ],
+    }
+    env = Environment.from_postman_export(data)
+    assert env.inline_value("base_url") == "https://api.example.com"
+
+
+def test_disabled_value_is_ignored():
+    data = {
+        "values": [
+            {"key": "base_url", "value": "https://old", "enabled": False, "type": "default"},
+        ],
+    }
+    env = Environment.from_postman_export(data)
+    # disabled -> not known -> not inlined -> becomes a fixture
+    assert env.inline_value("base_url") is None
+
+
+def test_missing_enabled_defaults_to_enabled():
+    # Postman sometimes omits "enabled" for active variables.
+    data = {"values": [{"key": "base_url", "value": "https://api", "type": "default"}]}
+    env = Environment.from_postman_export(data)
+    assert env.inline_value("base_url") == "https://api"
+
+
+def test_secret_typed_value_is_never_inlined():
+    data = {
+        "values": [
+            {"key": "auth_token", "value": "s3cr3t", "enabled": True, "type": "secret"},
+        ],
+    }
+    env = Environment.from_postman_export(data)
+    # secret value must NOT leak into generated source -> resolves to a fixture
+    assert env.inline_value("auth_token") is None
+    assert env.is_secret("auth_token") is True
+
+
+def test_unknown_variable_is_not_inlined():
+    env = Environment.from_postman_export({"values": []})
+    assert env.inline_value("whatever") is None
+    assert env.is_secret("whatever") is False
+
+
+def test_missing_values_key_yields_empty_env():
+    env = Environment.from_postman_export({"name": "empty"})
+    assert env.inline_value("base_url") is None
+
+
+def test_blank_or_missing_key_entries_are_skipped():
+    data = {"values": [{"value": "x", "enabled": True}, {"key": "", "value": "y"}]}
+    env = Environment.from_postman_export(data)
+    assert env.inline_value("") is None
+
+
+# -- needs_fixture: which {{vars}} become named pytest fixtures --
+
+
+def test_needs_fixture_for_secret_and_unknown_but_not_for_inlined():
+    data = {
+        "values": [
+            {"key": "base_url", "value": "https://api", "enabled": True, "type": "default"},
+            {"key": "auth_token", "value": "s3cr3t", "enabled": True, "type": "secret"},
+        ],
+    }
+    env = Environment.from_postman_export(data)
+    assert env.needs_fixture("base_url") is False  # inlined
+    assert env.needs_fixture("auth_token") is True  # secret -> fixture
+    assert env.needs_fixture("missing") is True  # unknown -> fixture
+
+
+# -- load_environment: file loading --
+
+
+def test_load_environment_reads_json_file(tmp_path: Path):
+    p = tmp_path / "env.json"
+    p.write_text(
+        json.dumps({"values": [{"key": "base_url", "value": "https://x", "enabled": True}]}),
+        encoding="utf-8",
+    )
+    env = load_environment(p)
+    assert env.inline_value("base_url") == "https://x"
+
+
+def test_load_environment_missing_file_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        load_environment(tmp_path / "nope.json")
+
+
+# -- generator wiring: env-aware ENV_xxx rendering --
+
+
+def _env(values):
+    from core.environment import Environment as _E
+
+    return _E.from_postman_export({"values": values})
+
+
+def test_render_url_inlines_non_secret_value():
+    from core.generator import _render_url
+
+    env = _env([{"key": "base_url", "value": "https://api.example.com", "enabled": True}])
+    out = _render_url("ENV_base_url/users", env)
+    assert "https://api.example.com/users" in out
+    assert "os.environ" not in out
+
+
+def test_render_url_unknown_path_var_becomes_fixture_ref():
+    from core.generator import _render_url
+
+    # with --env, an unknown mid-path var becomes a bare fixture reference
+    env = _env([{"key": "base_url", "value": "https://api.example.com", "enabled": True}])
+    out = _render_url("path/ENV_ver/users", env)  # relative, base_url not the prefix here
+    assert "{ver}" in out
+    assert "os.environ" not in out
+
+
+def test_render_secret_value_becomes_fixture_ref_not_inlined():
+    from core.generator import _render_header_value
+
+    env = _env([{"key": "token", "value": "s3cr3t", "enabled": True, "type": "secret"}])
+    out = _render_header_value("Bearer ENV_token", env)
+    assert "s3cr3t" not in out  # secret never inlined into source
+    assert "{token}" in out  # secret resolves to a fixture, not inline os.environ
+    assert "os.environ" not in out
+
+
+def test_render_header_inlines_non_secret_value():
+    from core.generator import _render_header_value
+
+    env = _env([{"key": "ver", "value": "v2", "enabled": True}])
+    out = _render_header_value("ENV_ver", env)
+    assert out == '"v2"'
+    assert "os.environ" not in out
+
+
+def test_render_header_unknown_becomes_fixture_ref():
+    from core.generator import _render_header_value
+
+    env = _env([])  # var not in env -> fixture
+    out = _render_header_value("Bearer ENV_token", env)
+    assert "{token}" in out
+    assert "os.environ" not in out
+
+
+def test_render_without_env_is_unchanged_backward_compatible():
+    from core.generator import _render_url
+
+    out = _render_url("path/ENV_ver/users", None)
+    assert "os.environ.get('ver'" in out
+
+
+# -- Part B: fixture generation end to end --
+
+
+def _collection_with_vars():
+    return {
+        "info": {
+            "name": "C",
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        },
+        "item": [
+            {
+                "name": "get user",
+                "request": {
+                    "method": "GET",
+                    "url": {"raw": "{{base_url}}/users"},
+                    "header": [
+                        {"key": "Authorization", "value": "Bearer {{auth_token}}"},
+                        {"key": "X-Api-Version", "value": "{{api_ver}}"},
+                    ],
+                },
+            }
+        ],
+    }
+
+
+def test_generate_emits_fixtures_for_secret_and_unknown(tmp_path: Path):
+    from core.generator import generate
+    from core.parser import parse_collection
+
+    cpath = tmp_path / "c.json"
+    cpath.write_text(json.dumps(_collection_with_vars()), encoding="utf-8")
+    reqs = parse_collection(cpath)
+    env = _env(
+        [
+            {"key": "base_url", "value": "https://api.example.com", "enabled": True},
+            {"key": "auth_token", "value": "SUPERSECRET", "enabled": True, "type": "secret"},
+        ]
+    )  # api_ver is unknown -> fixture
+    out = tmp_path / "t.py"
+    generate(reqs, collection_name="C", output_path=out, postman_env=env)
+    text = out.read_text(encoding="utf-8")
+
+    assert "def auth_token():" in text  # secret -> fixture
+    assert "def api_ver():" in text  # unknown -> fixture
+    assert "SUPERSECRET" not in text  # secret value never inlined
+    assert "https://api.example.com/users" in text  # non-secret inlined
+    # the test takes the fixtures it uses, sorted, as parameters
+    assert "(api_ver, auth_token):" in text
+    assert "{auth_token}" in text  # bare fixture reference, not os.environ
+    # generated file is valid Python
+    compile(text, str(out), "exec")
+
+
+def test_generate_without_env_emits_no_fixtures(tmp_path: Path):
+    from core.generator import generate
+    from core.parser import parse_collection
+
+    cpath = tmp_path / "c.json"
+    cpath.write_text(json.dumps(_collection_with_vars()), encoding="utf-8")
+    reqs = parse_collection(cpath)
+    out = tmp_path / "t.py"
+    generate(reqs, collection_name="C", output_path=out, postman_env=None)
+    text = out.read_text(encoding="utf-8")
+
+    assert "@pytest.fixture" not in text  # legacy path: no fixtures
+    assert "os.environ.get('auth_token'" in text  # legacy inline lookup
+    compile(text, str(out), "exec")
+
+
+def test_render_url_inlined_base_with_path_var_keeps_var_as_fixture():
+    # regression: inlining base_url made the URL absolute, which short-circuited
+    # to json.dumps and leaked any remaining {{var}} as a raw ENV_xxx token.
+    from core.generator import _render_url
+
+    env = _env([{"key": "base_url", "value": "https://api.example.com", "enabled": True}])
+    out = _render_url("ENV_base_url/orders/ENV_region", env)
+    assert "ENV_region" not in out  # raw token must never leak
+    assert "{region}" in out  # region -> fixture reference
+    assert "https://api.example.com/orders/" in out
+
+
+def test_collect_fixtures_includes_path_var_after_inlined_base(tmp_path: Path):
+    from core.generator import generate
+    from core.parser import parse_collection
+
+    col = {
+        "info": {
+            "name": "C",
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        },
+        "item": [
+            {
+                "name": "list",
+                "request": {"method": "GET", "url": {"raw": "{{base_url}}/orders/{{region}}"}},
+            }
+        ],
+    }
+    cpath = tmp_path / "c.json"
+    cpath.write_text(json.dumps(col), encoding="utf-8")
+    reqs = parse_collection(cpath)
+    env = _env([{"key": "base_url", "value": "https://api.example.com", "enabled": True}])
+    out = tmp_path / "t.py"
+    generate(reqs, collection_name="C", output_path=out, postman_env=env)
+    text = out.read_text(encoding="utf-8")
+    assert "def region():" in text
+    assert "(region):" in text
+    # the executable URL resolves the path var to the fixture, not a raw token
+    assert 'url = f"https://api.example.com/orders/{region}"' in text
+    compile(text, str(out), "exec")
+
+
+# -- safe fixture names (review M1 / Mi1) --
+
+
+def test_non_identifier_var_name_falls_back_and_compiles(tmp_path: Path):
+    from core.generator import generate
+    from core.parser import parse_collection
+
+    col = {
+        "info": {
+            "name": "C",
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        },
+        "item": [
+            {
+                "name": "mfa",
+                "request": {"method": "GET", "url": {"raw": "{{base_url}}/login/{{2fa}}"}},
+            }
+        ],
+    }
+    cpath = tmp_path / "c.json"
+    cpath.write_text(json.dumps(col), encoding="utf-8")
+    reqs = parse_collection(cpath)
+    env = _env([{"key": "base_url", "value": "https://api.example.com", "enabled": True}])
+    out = tmp_path / "t.py"
+    generate(reqs, collection_name="C", output_path=out, postman_env=env)
+    text = out.read_text(encoding="utf-8")
+
+    assert "def 2fa():" not in text  # not a (invalid) fixture
+    assert "os.environ.get('2fa'" in text  # safe os.environ fallback
+    compile(text, str(out), "exec")  # must be valid Python
+
+
+def test_reserved_name_var_does_not_become_fixture(tmp_path: Path):
+    from core.generator import generate
+    from core.parser import parse_collection
+
+    col = {
+        "info": {
+            "name": "C",
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        },
+        "item": [
+            {
+                "name": "r",
+                "request": {
+                    "method": "GET",
+                    "url": {"raw": "{{base_url}}/x"},
+                    "header": [{"key": "X-Url", "value": "{{url}}"}],
+                },
+            }
+        ],
+    }
+    cpath = tmp_path / "c.json"
+    cpath.write_text(json.dumps(col), encoding="utf-8")
+    reqs = parse_collection(cpath)
+    env = _env([{"key": "base_url", "value": "https://api.example.com", "enabled": True}])
+    out = tmp_path / "t.py"
+    generate(reqs, collection_name="C", output_path=out, postman_env=env)
+    text = out.read_text(encoding="utf-8")
+
+    # 'url' would shadow the local url variable -> routed to os.environ instead
+    assert "os.environ.get('url'" in text
+    compile(text, str(out), "exec")
+
+
+def test_load_environment_malformed_json_raises(tmp_path: Path):
+    p = tmp_path / "bad.json"
+    p.write_text("{ this is not json", encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        load_environment(p)


### PR DESCRIPTION
Implements #1.

Adds a `--env` flag that loads a Postman environment JSON export and resolves `{{variables}}` in the generated tests:

- Non-secret variables are inlined as literal values.
- Variables marked `secret` in the export, and any variable not present in it, become named pytest fixtures: the test takes them as parameters and the fixture reads from the environment at run time. A secret value never lands in the generated source.
- Variable names that are not valid, non-colliding Python identifiers fall back to `os.environ` lookups so the generated file always compiles.
- Without `--env`, behaviour is unchanged.

Resolution covers URLs and headers. Body and form-field variables are out of scope for now.

Tests: 23 new tests in `tests/test_environment.py`; full suite (133) green; ruff clean.

Closes #1
