### PR TITLE
feat: support OpenAPI 3.x specs as input format (closes #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- OpenAPI 3.x specs are accepted as an alternative input format (closes #10).
+  Pass `--input-format openapi` to generate a pytest suite from an OpenAPI 3.x
+  JSON or YAML spec instead of a Postman collection. A new `core/openapi_parser`
+  maps each operation to the same `ParsedRequest` shape the Postman parser
+  emits, so the generator and templates are unchanged: path parameters
+  (`/users/{id}`), query parameters, and header parameters become `os.environ`
+  placeholders, a JSON request body is built from the operation example or
+  schema, the expected status is the lowest 2xx response, and operations are
+  grouped by their first tag so `--filter-folder` works. Default input format
+  stays `postman`, so existing behaviour is unchanged. Adds a `pyyaml`
+  dependency for YAML specs.
 - Auth headers now extract into a shared `auth_headers` fixture (closes #2).
   Authorization Bearer/Basic and API-key headers are detected, pulled out of
   each generated test, and centralised in an `auth_headers` fixture written to a

--- a/README.md
+++ b/README.md
@@ -58,12 +58,37 @@ BASE_URL=https://staging.example.com pytest generated_tests/test_api.py -v
 
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--collection` | ✅ | Path to Postman Collection v2.1 JSON |
+| `--collection` | ✅ | Path to the input file: a Postman Collection v2.1 JSON, or an OpenAPI 3.x spec with `--input-format openapi` |
 | `--out` | ✅ | Output path for generated pytest file |
+| `--input-format` | ❌ | `postman` (default) or `openapi` (OpenAPI 3.x JSON or YAML) |
 | `--base-url` | ❌ | Tip printed after generation (does not override env var) |
 | `--filter-folder` | ❌ | Generate tests only for the named Postman folder |
 | `--env` | ❌ | Postman environment JSON export to resolve `{{variables}}` |
 | `--max-input-mb` | ❌ | Refuse to load collections larger than this many MB (default: 100) |
+
+### OpenAPI 3.x input
+
+If your API is documented as an OpenAPI 3.x spec instead of a Postman
+collection, pass `--input-format openapi`. JSON and YAML specs are both
+accepted:
+
+```bash
+postman2pytest \
+  --collection openapi/my_api.yaml \
+  --input-format openapi \
+  --out generated_tests/test_api.py
+```
+
+The generated suite has the same shape as the Postman path. Path parameters
+(`/users/{id}`), query parameters, and header parameters map to `os.environ`
+lookups, and a JSON request body is generated from the operation's example or
+schema. Operations are grouped by their first tag (used as the folder name), so
+`--filter-folder` works the same way.
+
+Notes for this first version: the base URL always comes from the `BASE_URL`
+environment variable, so any path in the spec's `servers` list is ignored (put
+the version prefix in `BASE_URL`). `$ref` references are not resolved, so a
+request body defined purely by a `$ref` is generated empty.
 
 To regenerate tests for one folder, pass its Postman folder name:
 

--- a/core/generator.py
+++ b/core/generator.py
@@ -59,7 +59,7 @@ def _inline_env_tokens(value: str, env: PostmanEnvironment | None) -> str:
     return _ENV_VAR_RE.sub(repl, value)
 
 
-def _strip_base_url(url: str, fixture_mode: bool = False) -> str:
+def _strip_base_url(url: str, fixture_mode: bool = False, strip_leading: bool = True) -> str:
     """
     Transform ENV_xxx URLs for use in f-strings inside generated tests.
 
@@ -77,12 +77,13 @@ def _strip_base_url(url: str, fixture_mode: bool = False) -> str:
     """
     if url.startswith(("http://", "https://")):
         return url
-    url = _ENV_PREFIX_RE.sub("", url)
+    if strip_leading:
+        url = _ENV_PREFIX_RE.sub("", url)
     url = _ENV_VAR_RE.sub(lambda m: _token_repr(m.group(1), fixture_mode), url)
     return url
 
 
-def _render_url(url: str, env: PostmanEnvironment | None = None) -> str:
+def _render_url(url: str, env: PostmanEnvironment | None = None, strip_leading: bool = True) -> str:
     """Render a URL as a Python expression for the generated test code.
 
     When an environment is provided, non-secret known variables are inlined
@@ -110,7 +111,7 @@ def _render_url(url: str, env: PostmanEnvironment | None = None) -> str:
         # base_url followed by a path variable). Render as an f-string so the
         # remaining tokens are interpolated instead of leaking as raw text.
         return 'f"' + _interpolate(url, fixture_mode) + '"'
-    stripped = _strip_base_url(url, fixture_mode=fixture_mode)
+    stripped = _strip_base_url(url, fixture_mode=fixture_mode, strip_leading=strip_leading)
     return 'f"{BASE_URL}/' + stripped + '"'
 
 
@@ -238,7 +239,7 @@ def _collect_fixtures(req: ParsedRequest, env: PostmanEnvironment | None) -> lis
         names.update(n for n in _ENV_VAR_RE.findall(text) if _is_safe_fixture_name(n))
 
     url = _inline_env_tokens(req.url, env)
-    if not url.startswith(("http://", "https://")):
+    if not url.startswith(("http://", "https://")) and req.strip_leading_url_var:
         url = _ENV_PREFIX_RE.sub("", url)  # relative: leading var -> BASE_URL, not a fixture
     _add_safe(url)  # remaining url vars (absolute or relative)
 
@@ -276,7 +277,9 @@ def generate(
     )
     env.filters["tojson"] = _to_python_repr
     env.filters["strip_base_url"] = _strip_base_url
-    env.filters["render_url"] = lambda url: _render_url(url, postman_env)
+    env.filters["render_url"] = lambda url, strip_leading=True: _render_url(
+        url, postman_env, strip_leading
+    )
     env.filters["render_header_value"] = lambda value: _render_header_value(value, postman_env)
 
     template = env.get_template("test_collection.jinja2")

--- a/core/openapi_parser.py
+++ b/core/openapi_parser.py
@@ -1,0 +1,269 @@
+"""
+OpenAPI 3.x parser.
+
+Parses an OpenAPI 3.x specification (JSON or YAML) into the same list of
+ParsedRequest objects the Postman parser emits, so the existing generator and
+templates render an identical-shape pytest suite from either input format.
+
+Path parameters ({id}) and query/header parameters are mapped to the same
+ENV_xxx placeholder mechanism the Postman path uses: a path segment {id}
+becomes {{id}} which ParsedRequest normalises to ENV_id, and the generator then
+renders it as an os.environ lookup (or a fixture under --env). This keeps a
+single downstream code path for both input formats.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from core.parser import ParsedRequest, _disambiguate, _replace_vars, _slugify
+
+logger = logging.getLogger(__name__)
+
+# HTTP methods an OpenAPI Path Item Object may declare (OpenAPI 3.x fixed fields).
+_HTTP_METHODS = ("get", "put", "post", "delete", "options", "head", "patch", "trace")
+
+# A path-template placeholder: the {name} spans in an OpenAPI path (e.g. /users/{id}).
+_PATH_PARAM_RE = re.compile(r"\{([^}]+)\}")
+
+
+def _sanitize_var(name: str) -> str:
+    """Reduce a parameter name to the \\w+ token ParsedRequest recognises.
+
+    ParsedRequest replaces {{name}} with ENV_name only when name matches \\w+,
+    so a header/path/query parameter like 'X-Request-Id' must collapse to
+    'X_Request_Id' before it is wrapped as a placeholder.
+    """
+    cleaned = re.sub(r"\W+", "_", name).strip("_")
+    return cleaned or "param"
+
+
+def _load_spec(path: Path) -> Any:
+    """Load an OpenAPI spec from JSON or YAML.
+
+    YAML is chosen by extension (.yaml/.yml); otherwise JSON is tried first and
+    YAML is used as a fallback (a .json extension is trusted, but an unknown
+    extension still parses a YAML document, which is a superset of JSON).
+    """
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+    if suffix in (".yaml", ".yml"):
+        import yaml
+
+        return yaml.safe_load(text)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        import yaml
+
+        return yaml.safe_load(text)
+
+
+def _placeholder_for_schema(schema: dict[str, Any]) -> Any:
+    """A concrete sample value for a property schema.
+
+    Prefers an explicit example/default, then an enum's first option, then a
+    type-appropriate empty value. Used to synthesise a JSON request body when
+    the spec carries no example of its own.
+    """
+    if not isinstance(schema, dict):
+        return ""
+    if "example" in schema:
+        return schema["example"]
+    if "default" in schema:
+        return schema["default"]
+    enum = schema.get("enum")
+    if isinstance(enum, list) and enum:
+        return enum[0]
+    kind = schema.get("type", "")
+    return {
+        "integer": 0,
+        "number": 0,
+        "boolean": False,
+        "array": [],
+        "object": {},
+        "string": "",
+    }.get(kind, "")
+
+
+def _example_body(operation: dict[str, Any]) -> str | None:
+    """Build a raw JSON body string from an operation's JSON requestBody.
+
+    Uses a media-type example, then a schema example, then a skeleton built
+    from the schema properties. Returns None when there is no JSON body to send.
+    """
+    request_body = operation.get("requestBody")
+    if not isinstance(request_body, dict):
+        return None
+    content = request_body.get("content")
+    if not isinstance(content, dict):
+        return None
+    media = content.get("application/json")
+    if not isinstance(media, dict):
+        return None
+
+    if "example" in media:
+        return json.dumps(media["example"])
+
+    schema = media.get("schema")
+    if isinstance(schema, dict):
+        if "example" in schema:
+            return json.dumps(schema["example"])
+        properties = schema.get("properties")
+        if isinstance(properties, dict) and properties:
+            skeleton = {name: _placeholder_for_schema(prop) for name, prop in properties.items()}
+            return json.dumps(skeleton)
+    return None
+
+
+def _merge_parameters(path_item: dict[str, Any], operation: dict[str, Any]) -> list[dict[str, Any]]:
+    """Combine path-item-level and operation-level parameters.
+
+    An operation-level parameter overrides a path-item one that shares the same
+    (name, in) pair, per the OpenAPI specification.
+    """
+    merged: dict[tuple[str, str], dict[str, Any]] = {}
+    for source in (path_item.get("parameters", []), operation.get("parameters", [])):
+        if not isinstance(source, list):
+            continue
+        for param in source:
+            if not isinstance(param, dict) or "name" not in param:
+                continue
+            merged[(param["name"], param.get("in", ""))] = param
+    return list(merged.values())
+
+
+def _expected_status(operation: dict[str, Any]) -> int:
+    """Pick the lowest 2xx response code, defaulting to 200.
+
+    Mirrors the Postman path, whose expected_status also defaults to 200 when a
+    collection carries no explicit status assertion.
+    """
+    responses = operation.get("responses")
+    if isinstance(responses, dict):
+        codes = [
+            int(code)
+            for code in responses
+            if isinstance(code, str) and code.isdigit() and 200 <= int(code) < 300
+        ]
+        if codes:
+            return min(codes)
+    return 200
+
+
+def _build_url(path: str, params: list[dict[str, Any]]) -> str:
+    """Assemble a relative URL with {{var}} placeholders for path/query params.
+
+    Path template segments {id} become {{id}}; query parameters are appended as
+    key={{key}} pairs. The leading slash is dropped so the generator's relative
+    URL path (f"{BASE_URL}/...") does not produce a double slash.
+    """
+    templated = _PATH_PARAM_RE.sub(lambda m: "{{" + _sanitize_var(m.group(1)) + "}}", path)
+    templated = templated.lstrip("/")
+
+    query = [p for p in params if p.get("in") == "query"]
+    if query:
+        pairs = [f"{p['name']}={{{{{_sanitize_var(p['name'])}}}}}" for p in query]
+        templated = f"{templated}?{'&'.join(pairs)}"
+    return templated
+
+
+def _operation_name(method: str, path: str, operation: dict[str, Any]) -> str:
+    """Human-ish request name: operationId, then summary, then 'METHOD path'."""
+    for key in ("operationId", "summary"):
+        value = operation.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return f"{method.upper()} {path}"
+
+
+def spec_title(path: Path) -> str | None:
+    """Return the spec's info.title, or None when it cannot be read.
+
+    Used by the CLI to name the generated suite, mirroring how the Postman path
+    reads info.name.
+    """
+    try:
+        data = _load_spec(path)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+    if isinstance(data, dict):
+        info = data.get("info")
+        if isinstance(info, dict):
+            title = info.get("title")
+            if isinstance(title, str) and title.strip():
+                return title.strip()
+    return None
+
+
+def parse_openapi(path: Path) -> list[ParsedRequest]:
+    """Parse an OpenAPI 3.x spec (JSON or YAML) into a list of ParsedRequest.
+
+    Each operation under paths becomes one ParsedRequest whose shape matches the
+    Postman parser's output, so the generator renders both formats identically.
+    """
+    data = _load_spec(path)
+    if not isinstance(data, dict):
+        raise ValueError(f"OpenAPI spec root must be a mapping, got {type(data).__name__}.")
+
+    version = data.get("openapi", "")
+    if not (isinstance(version, str) and version.startswith("3.")):
+        logger.warning("Unexpected or missing openapi version: %r. Proceeding anyway.", version)
+
+    paths = data.get("paths", {})
+    if not isinstance(paths, dict):
+        logger.warning(
+            "'paths' is not a mapping (got %s); treating as empty.", type(paths).__name__
+        )
+        paths = {}
+
+    results: list[ParsedRequest] = []
+    for path_str, path_item in paths.items():
+        if not isinstance(path_item, dict):
+            logger.warning("Skipping path '%s': item is not a mapping.", path_str)
+            continue
+        for method in _HTTP_METHODS:
+            operation = path_item.get(method)
+            if not isinstance(operation, dict):
+                continue
+            try:
+                params = _merge_parameters(path_item, operation)
+                # ParsedRequest has no header validator (unlike url), so resolve
+                # the {{name}} placeholder to an ENV_ token here, exactly as the
+                # Postman parser does for its own header values.
+                headers = {
+                    p["name"]: _replace_vars("{{" + _sanitize_var(p["name"]) + "}}")
+                    for p in params
+                    if p.get("in") == "header"
+                }
+                tags = operation.get("tags")
+                folder = None
+                if isinstance(tags, list) and tags and isinstance(tags[0], str):
+                    slug = _slugify(tags[0])
+                    folder = slug if slug != "unnamed" else None
+
+                results.append(
+                    ParsedRequest(
+                        name=_operation_name(method, path_str, operation),
+                        method=method,
+                        url=_build_url(path_str, params),
+                        headers=headers,
+                        body=_example_body(operation),
+                        expected_status=_expected_status(operation),
+                        folder=folder,
+                        # OpenAPI URLs are base-URL-relative with no leading
+                        # base-URL variable, so a leading path parameter must
+                        # survive generation (see ParsedRequest field docs).
+                        strip_leading_url_var=False,
+                    )
+                )
+            except (KeyError, TypeError, ValueError, AttributeError) as exc:
+                logger.warning("Skipping %s %s: %s", method.upper(), path_str, exc)
+
+    _disambiguate(results)
+    logger.info("Parsed %d requests from OpenAPI spec", len(results))
+    return results

--- a/core/parser.py
+++ b/core/parser.py
@@ -173,6 +173,11 @@ class ParsedRequest(BaseModel):
     assertions: list[Assertion] = []  # translated from Postman test scripts
     folder: str | None
     final_test_name: str = ""  # filled by _disambiguate after parse
+    # Postman collections carry the base URL as the leading {{var}} of each URL,
+    # which the generator strips before prepending BASE_URL. OpenAPI paths never
+    # do; a leading path parameter (/{tenant}/...) must NOT be stripped. Parsers
+    # that emit base-URL-relative paths set this False.
+    strip_leading_url_var: bool = True
 
     @field_validator("method")
     @classmethod

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from core.environment import load_environment
 from core.generator import generate
+from core.openapi_parser import parse_openapi, spec_title
 from core.parser import ParsedRequest, parse_collection
 
 try:
@@ -43,7 +44,17 @@ def main() -> int:
     )
     parser.add_argument("--version", action="version", version=f"postman2pytest {__version__}")
     parser.add_argument(
-        "--collection", required=True, help="Path to Postman Collection JSON file (.json)"
+        "--collection",
+        required=True,
+        help="Path to the input file: a Postman Collection (.json) or, with "
+        "--input-format openapi, an OpenAPI 3.x spec (.json/.yaml)",
+    )
+    parser.add_argument(
+        "--input-format",
+        choices=["postman", "openapi"],
+        default="postman",
+        help="Input format: 'postman' (Postman Collection v2.1, default) or "
+        "'openapi' (OpenAPI 3.x JSON or YAML)",
     )
     parser.add_argument(
         "--out",
@@ -88,21 +99,25 @@ def main() -> int:
         )
         return 1
 
-    try:
-        collection_name = (
-            json.loads(collection_path.read_text(encoding="utf-8"))
-            .get("info", {})
-            .get("name", collection_path.stem)
-        )
-    except (json.JSONDecodeError, OSError, KeyError) as exc:
-        logger.warning(
-            "Could not read collection name from %s: %s. Falling back to file stem.",
-            collection_path,
-            exc,
-        )
-        collection_name = collection_path.stem
+    if args.input_format == "openapi":
+        collection_name = spec_title(collection_path) or collection_path.stem
+        requests = parse_openapi(collection_path)
+    else:
+        try:
+            collection_name = (
+                json.loads(collection_path.read_text(encoding="utf-8"))
+                .get("info", {})
+                .get("name", collection_path.stem)
+            )
+        except (json.JSONDecodeError, OSError, KeyError) as exc:
+            logger.warning(
+                "Could not read collection name from %s: %s. Falling back to file stem.",
+                collection_path,
+                exc,
+            )
+            collection_name = collection_path.stem
 
-    requests = parse_collection(collection_path)
+        requests = parse_collection(collection_path)
     if args.filter_folder:
         requests = filter_requests_by_folder(requests, args.filter_folder)
         if not requests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "jinja2>=3.1,<4",
     "requests>=2.31,<3",
     "unidecode>=1.3,<2",
+    "pyyaml>=6,<7",
 ]
 
 [project.optional-dependencies]
@@ -37,6 +38,7 @@ dev = [
     "ruff>=0.4",
     "mypy>=1.8",
     "types-requests",
+    "types-PyYAML",
 ]
 
 [[project.authors]]

--- a/templates/test_collection.jinja2
+++ b/templates/test_collection.jinja2
@@ -23,7 +23,7 @@ def {{ name }}():
 {% for req in requests %}
 def {{ req.test_name }}({{ params_per_request[loop.index0] }}):
     """{{ req.method }} {{ req.url }}{% if req.folder %} ({{ req.folder }}){% endif %}"""
-    url = {{ req.url | render_url }}
+    url = {{ req.url | render_url(req.strip_leading_url_var) }}
     {% set non_auth = non_auth_per_request[loop.index0] %}
     {% if has_auth_per_request[loop.index0] or non_auth %}
     headers = {

--- a/tests/test_openapi_parser.py
+++ b/tests/test_openapi_parser.py
@@ -1,0 +1,296 @@
+"""Tests for core/openapi_parser.py (OpenAPI 3.x input support, issue #10)."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from core.generator import generate
+from core.openapi_parser import parse_openapi
+
+# --- Sample spec covering the three acceptance-criteria endpoints -------------
+
+
+def _sample_spec() -> dict:
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "Sample API", "version": "1.0.0"},
+        "paths": {
+            "/users": {
+                "get": {
+                    "operationId": "listUsers",
+                    "tags": ["users"],
+                    "parameters": [
+                        {"name": "status", "in": "query", "schema": {"type": "string"}},
+                        {"name": "limit", "in": "query", "schema": {"type": "integer"}},
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+                "post": {
+                    "operationId": "createUser",
+                    "tags": ["users"],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "age": {"type": "integer"},
+                                    },
+                                }
+                            }
+                        }
+                    },
+                    "responses": {"201": {"description": "created"}},
+                },
+            },
+            "/users/{id}": {
+                "get": {
+                    "operationId": "getUser",
+                    "tags": ["users"],
+                    "parameters": [
+                        {"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            },
+        },
+    }
+
+
+def _write_json(tmp_path: Path, spec: dict) -> Path:
+    p = tmp_path / "spec.json"
+    p.write_text(json.dumps(spec), encoding="utf-8")
+    return p
+
+
+def _write_yaml(tmp_path: Path, spec: dict) -> Path:
+    p = tmp_path / "spec.yaml"
+    p.write_text(yaml.safe_dump(spec), encoding="utf-8")
+    return p
+
+
+def _by_name(requests, method: str, url_fragment: str):
+    for req in requests:
+        if req.method == method.upper() and url_fragment in req.url:
+            return req
+    raise AssertionError(
+        f"no {method} request with url fragment {url_fragment!r} in {[(r.method, r.url) for r in requests]}"
+    )
+
+
+# --- Core parsing ------------------------------------------------------------
+
+
+def test_parse_openapi_returns_one_request_per_operation(tmp_path):
+    reqs = parse_openapi(_write_json(tmp_path, _sample_spec()))
+    assert len(reqs) == 3  # GET /users, POST /users, GET /users/{id}
+
+
+def test_get_with_query_params(tmp_path):
+    reqs = parse_openapi(_write_json(tmp_path, _sample_spec()))
+    req = _by_name(reqs, "GET", "users?")
+    assert req.method == "GET"
+    # {{status}}/{{limit}} normalise to ENV_ tokens via ParsedRequest.url validator
+    assert "ENV_status" in req.url
+    assert "ENV_limit" in req.url
+    assert req.body is None
+
+
+def test_post_with_json_body(tmp_path):
+    reqs = parse_openapi(_write_json(tmp_path, _sample_spec()))
+    req = _by_name(reqs, "POST", "users")
+    assert req.method == "POST"
+    assert req.body is not None
+    payload = json.loads(req.body)  # body is a raw JSON string, same shape as Postman path
+    assert set(payload.keys()) == {"name", "age"}
+    assert req.expected_status == 201
+
+
+def test_get_with_path_param(tmp_path):
+    reqs = parse_openapi(_write_json(tmp_path, _sample_spec()))
+    req = _by_name(reqs, "GET", "users/ENV_id")
+    assert req.method == "GET"
+    assert "ENV_id" in req.url
+    assert "{id}" not in req.url
+
+
+def test_expected_status_defaults_to_200_when_no_2xx(tmp_path):
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "x", "version": "1"},
+        "paths": {"/ping": {"get": {"responses": {"default": {"description": "d"}}}}},
+    }
+    reqs = parse_openapi(_write_json(tmp_path, spec))
+    assert reqs[0].expected_status == 200
+
+
+def test_header_param_becomes_request_header(tmp_path):
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "x", "version": "1"},
+        "paths": {
+            "/thing": {
+                "get": {
+                    "parameters": [
+                        {"name": "X-Request-Id", "in": "header", "schema": {"type": "string"}}
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    reqs = parse_openapi(_write_json(tmp_path, spec))
+    assert "X-Request-Id" in reqs[0].headers
+    # value must resolve to an ENV_ token, not the literal {{...}} placeholder,
+    # so the generator renders it as an os.environ lookup
+    assert reqs[0].headers["X-Request-Id"] == "ENV_X_Request_Id"
+    out = tmp_path / "gen" / "test_api.py"
+    generate(reqs, collection_name="x", output_path=out)
+    assert "os.environ.get('X_Request_Id', '')" in out.read_text(encoding="utf-8")
+
+
+def test_leading_path_param_survives_generation(tmp_path):
+    # /{tenant}/users starts with a parameter; it must not be mistaken for a
+    # base-URL variable and stripped by the generator.
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "x", "version": "1"},
+        "paths": {
+            "/{tenant}/users": {
+                "get": {
+                    "operationId": "listTenantUsers",
+                    "parameters": [
+                        {
+                            "name": "tenant",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        }
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    reqs = parse_openapi(_write_json(tmp_path, spec))
+    assert reqs[0].url == "{tenant}/users".replace("{tenant}", "ENV_tenant")
+    out = tmp_path / "gen" / "test_api.py"
+    generate(reqs, collection_name="x", output_path=out)
+    text = out.read_text(encoding="utf-8")
+    assert "os.environ.get('tenant', '')" in text  # param survived, not stripped
+    assert "{BASE_URL}/users" not in text  # the buggy stripped form must not appear
+
+
+# --- JSON and YAML both accepted ---------------------------------------------
+
+
+def test_accepts_json_spec(tmp_path):
+    reqs = parse_openapi(_write_json(tmp_path, _sample_spec()))
+    assert len(reqs) == 3
+
+
+def test_accepts_yaml_spec(tmp_path):
+    reqs = parse_openapi(_write_yaml(tmp_path, _sample_spec()))
+    assert len(reqs) == 3
+
+
+def test_json_and_yaml_produce_identical_requests(tmp_path):
+    from_json = parse_openapi(_write_json(tmp_path, _sample_spec()))
+    from_yaml = parse_openapi(_write_yaml(tmp_path, _sample_spec()))
+    assert [(r.method, r.url) for r in from_json] == [(r.method, r.url) for r in from_yaml]
+
+
+# --- End-to-end: generated file is valid Python ------------------------------
+
+
+def test_generated_output_is_valid_python(tmp_path):
+    reqs = parse_openapi(_write_json(tmp_path, _sample_spec()))
+    out = tmp_path / "generated" / "test_api.py"
+    generate(reqs, collection_name="Sample API", output_path=out)
+    ast.parse(out.read_text(encoding="utf-8"))  # raises SyntaxError if malformed
+
+
+# --- Robustness --------------------------------------------------------------
+
+
+def test_empty_paths_returns_empty_list(tmp_path):
+    spec = {"openapi": "3.0.0", "info": {"title": "x", "version": "1"}, "paths": {}}
+    assert parse_openapi(_write_json(tmp_path, spec)) == []
+
+
+def test_non_object_root_raises(tmp_path):
+    p = tmp_path / "spec.json"
+    p.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    with pytest.raises(ValueError):
+        parse_openapi(p)
+
+
+def test_spec_title_reads_info_title(tmp_path):
+    from core.openapi_parser import spec_title
+
+    assert spec_title(_write_yaml(tmp_path, _sample_spec())) == "Sample API"
+
+
+# --- CLI wiring --------------------------------------------------------------
+
+
+def test_cli_input_format_openapi_end_to_end(tmp_path, monkeypatch, capsys):
+    import main
+
+    spec = _write_yaml(tmp_path, _sample_spec())
+    out = tmp_path / "test_api.py"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "postman2pytest",
+            "--collection",
+            str(spec),
+            "--input-format",
+            "openapi",
+            "--out",
+            str(out),
+        ],
+    )
+    assert main.main() == 0
+    assert out.exists()
+    ast.parse(out.read_text(encoding="utf-8"))
+    assert "3 test(s)" in capsys.readouterr().out
+
+
+def test_cli_default_input_format_is_postman(tmp_path, monkeypatch):
+    import main
+
+    collection = tmp_path / "c.json"
+    collection.write_text(
+        json.dumps(
+            {
+                "info": {
+                    "name": "C",
+                    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+                },
+                "item": [
+                    {
+                        "name": "ping",
+                        "request": {
+                            "method": "GET",
+                            "header": [],
+                            "url": {"raw": "{{base_url}}/ping"},
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "out.py"
+    monkeypatch.setattr(
+        "sys.argv", ["postman2pytest", "--collection", str(collection), "--out", str(out)]
+    )
+    assert main.main() == 0  # default path (postman) still works, no --input-format given
+    assert out.exists()


### PR DESCRIPTION
Adds OpenAPI 3.x (JSON or YAML) as an alternative input format via `--input-format openapi` (default stays `postman`).

## What
- New `core/openapi_parser.py`: `parse_openapi(path)` maps each operation to the same `ParsedRequest` shape the Postman parser emits, so `core/generator.py` and the templates render both formats identically.
- Path params (`/users/{id}`), query params, and header params become `os.environ` placeholders; a JSON body is built from the operation example or schema; expected status is the lowest 2xx; operations group by first tag so `--filter-folder` works.
- CLI: `--input-format {postman,openapi}`; the default `postman` path is unchanged.
- A leading path parameter (`/{tenant}/...`) is preserved via a per-request flag so the generator does not strip it as a base-URL variable.
- Adds `pyyaml` for YAML specs; README + CHANGELOG updated.

## Acceptance criteria (issue #10)
- [x] `--input-format` flag, `postman` (default) and `openapi`
- [x] paths, methods, path/query/header params, JSON bodies
- [x] output identical in shape to the Postman path
- [x] JSON and YAML specs
- [x] tests cover GET+query, POST+JSON body, GET+path param `{id}`
- [x] README example

## Verification
- 167 tests pass (16 new for OpenAPI; 151 existing Postman tests unchanged), ruff clean, mypy clean.

## Known v1 limitations (documented in README)
- `servers[].url` base path is ignored (base URL comes from `BASE_URL`).
- `$ref` references are not resolved (a body defined purely by `$ref` is generated empty).